### PR TITLE
Document.write breakpoint added

### DIFF
--- a/ie11_eval.wds
+++ b/ie11_eval.wds
@@ -3,5 +3,6 @@
 .foreach /s (exc "epr sbo sov gp ii av") {sxe ${exc}}
 sxe -c ".logclose" -h epr
 bu jscript9!Js::ScriptContext::IsInEvalMap ".echo EVAL(dyn)-----;.printf \"%mu\", poi(esp+0x18);.echo;g"
+bu MSHTML!CHTMLoad::Write ".echo DOCUMENT.WRITE-----;.printf \"%mu\",poi(esp+0x4);.echo;g"
 g
 


### PR DESCRIPTION
The document.write function is also commonly used in exploits and obfuscated JS. 
The added code creates a breakpoint for document.write, and logs the parameters the same way as it was logged for eval.